### PR TITLE
Easlinger/dev

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "DockerRun.DisableDockerrc": true
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,0 @@
-{
-    "DockerRun.DisableDockerrc": true
-}

--- a/scripts/create-multi-norm.R
+++ b/scripts/create-multi-norm.R
@@ -44,7 +44,13 @@ for (i in seq_len(nrow(samples))) {
     x@meta.data$group <- samples$group[i]
   } else {
     # it's assumed preformed objs have group and name metadata vars
-    x <- readRDS(samples$dir[i])
+    x <- readRDS(samples$dir[i])  # read Seurat object from RDS file
+    if ("object" %in% names(x@meta.data) == FALSE) {
+      x@meta.data$object <- samples$name[i]  # add name metadata if needed
+    }
+    if ("group" %in% names(x@meta.data) == FALSE) {
+      x@meta.data$group <- samples$group[i]  # add group metadata if needed
+    }
     x
   }
 

--- a/scripts/create-object-norm.R
+++ b/scripts/create-object-norm.R
@@ -38,7 +38,13 @@ for (i in seq_len(nrow(samples))) {
     # TODO add compatibility with hdf5 format
 
     # it's assumed preformed objs have group and name metadata vars
-    x <- readRDS(samples$dir[i])
+    x <- readRDS(samples$dir[i])  # read Seurat object from RDS file
+    if ("object" %in% names(x@meta.data) == FALSE) {
+      x@meta.data$object <- samples$name[i]  # add name metadata if needed
+    }
+    if ("group" %in% names(x@meta.data) == FALSE) {
+      x@meta.data$group <- samples$group[i]  # add group metadata if needed
+    }
     x
   }
 

--- a/scripts/create-object-sct.R
+++ b/scripts/create-object-sct.R
@@ -38,7 +38,13 @@ for (i in seq_len(nrow(samples))) {
     # TODO add compatibility with hdf5 format
 
     # it's assumed preformed objs have group and name metadata vars
-    x <- readRDS(samples$dir[i])
+    x <- readRDS(samples$dir[i])  # read Seurat object from RDS file
+    if ("object" %in% names(x@meta.data) == FALSE) {
+      x@meta.data$object <- samples$name[i]  # add name metadata if needed
+    }
+    if ("group" %in% names(x@meta.data) == FALSE) {
+      x@meta.data$group <- samples$group[i]  # add group metadata if needed
+    }
     x
   }
 


### PR DESCRIPTION
This commit adds code that assigns Seurat object metadata (pulled from sample file) if missing from the RDS object. This is useful when reading data from RDS file (instead of directory) that has been manually created (e.g., if need to extract one part of a multi-modal dataset). 

Sometimes these objects will not have the same metadata that is added in the CoreSC code when reading from a directory rather than an RDS file.